### PR TITLE
Ensure GFile is unreferenced to avoid filename memory leak

### DIFF
--- a/rsvg-base-file-util.c
+++ b/rsvg-base-file-util.c
@@ -116,6 +116,7 @@ rsvg_handle_new_from_file (const gchar * file_name, GError ** error)
     }
 
     g_free (base_uri);
+    g_object_unref (file);
 
     return handle;
 }


### PR DESCRIPTION
Hello @federicomenaquintero, thank you very much for all the time you continue to devote to librsvg.

v2.40.20 appears to have introduced a small memory leak of the filename that I think was via the change in commit https://github.com/GNOME/librsvg/commit/475764fcbb89fa24464c1e3a7097bf162a44198b

The change in this PR should ensure the GFile instance is unreferenced for all paths.

(The [Gnome GitLab instance](https://gitlab.gnome.org/GNOME) won't let me register - "Email is not from an allowed domain" - hence the use of GitHub.)
  